### PR TITLE
Product naming changes and repositioning Camel K

### DIFF
--- a/documentation/modules/ROOT/pages/02-architecture.adoc
+++ b/documentation/modules/ROOT/pages/02-architecture.adoc
@@ -29,20 +29,20 @@ As a migration does not bring immediate new business value, it's important that 
 * https://www.redhat.com/en/technologies/cloud-computing/openshift[Red Hat OpenShift]
 * Red Hat Application Foundation
 ** https://access.redhat.com/products/quarkus[Quarkus]
-** https://developers.redhat.com/products/redhat-build-of-camel/overview[Red Hat build of Camel]
+** https://developers.redhat.com/products/redhat-build-of-camel/overview[Red Hat build of Apache Camel]
 
 
 [#in_depth]
 == An in-depth look at the solution's architecture
 
-The Red Hat Build of Camel is an Cloud-native, multi-language and a multi-runtime integration stack.
+The Red Hat build of Apache Camel is an Cloud-native, multi-language and a multi-runtime integration stack.
 Camel-based integration logic can be written in XML or Java, and can behave as a Spring Boot, a Quarkus, or a Serverless artifact. 
 
 The present demo will take a legacy API developed in JBoss Fuse 6.2 on Karaf, in Blueprint XML.
 It's suggested that such an application targets the Quarkus runtime.
 The provided Quarkus template is 100% compatible with Camel K, so the resutling migrated application is immediately ready to be added to a serverless stack.
 
-The material can be used to migrate any Fuse 6 or 7 distribution to the Red Hat Build of Apache Camel.
+The material can be used to migrate any Fuse 6 or 7 distribution to the Red Hat build of Apache Camel.
 The demos will however focus on migrating a Fuse 6 application, and more concretely a Camel v2.17 one, in Blueprint XML format, running on Karaf 2. The XML format will be converted to the optimized IO XML one.
 This path has been chosen for the demonstration because it can be considered the hardest one. Applications running on Fuse 7, no matter which distribution, could use the same approach and will bnefit from a shortest migration effort.
 

--- a/documentation/modules/ROOT/pages/index.adoc
+++ b/documentation/modules/ROOT/pages/index.adoc
@@ -6,13 +6,13 @@
 
 Application Development is evolving as the modern Hybrid Cloud and cloud-native architectures drive new demands on applications.  As a part of this continual evolution, we are evolving our product offering from Red Hat Fuse to the Red Hat build of Apache Camel, allowing us to address a broader set of customer deployment use cases.
 
-As  Red Hat Fuse approaches product End of Life (EOL) on June 30, 2024,  Apache Camel is the natural go-forward solution for integrations built around Red Hat Fuse which is based on an older version of Apache Camel. Fuse will remain in the https://access.redhat.com/support/policy/updates/jboss_notes#phases[maintenance life cycle^] until its EOL. 
+As  Red Hat Fuse approaches product End of Life (EOL) on June 30, 2024,  Red Hat build of Apache Camel is the natural go-forward solution for integrations built around Red Hat Fuse which is based on an older version of Apache Camel. Fuse will remain in the https://access.redhat.com/support/policy/updates/jboss_notes#phases[maintenance life cycle^] until its EOL. 
 
-The https://developers.redhat.com/products/redhat-build-of-apache-camel/overview[Red Hat build of Apache Camel^] is the evolution for Red Hat Fuse, and  is a powerful, versatile framework for application integration. It also includes running Camel on Quarkus and Spring Boot runtimes in both on-premise and cloud environments, including the Camel K operator which is as great starting point for Camel deployments on OpenShift.
+The https://developers.redhat.com/products/redhat-build-of-apache-camel/overview[Red Hat build of Apache Camel^] is the evolution for Red Hat Fuse, and  is a powerful, versatile framework for application integration. It also includes running Camel on Quarkus and Spring Boot runtimes in both on-premise and cloud environments, including the Camel K operator which streamlines building, deploying and operating Camel integrations on OpenShift.
 
 Performing such a migration can be scary as the effort is not just limited to migrating the high level Camel routes. Indeed, many other underlying technical components (JDK version, Runtime type, XML format etc.) are involved in the migration.
 
-With this solution pattern you will find a guided way to perform *Apache Camel v2 to Camel v3 or v4 migrations* in a faster way. This solution pattern proposes an accelerated path to performing such a migration by abstracting all those technical details, leaving it to the migration of the high level integration logic .
+With this solution pattern you will find a guided way to perform *Apache Camel v2 to Camel v3 and v4 migrations* in a faster way. This solution pattern proposes an accelerated path to performing such a migration by abstracting all those technical details, leaving it to the migration of the high level integration logic .
 
 
 Contributors: _Michael Thirion (Red Hat)_
@@ -22,19 +22,19 @@ Contributors: _Michael Thirion (Red Hat)_
 
 Common use cases that can be address with this solution are:
 
-- Migrate Fuse 6.x (Blueprint XML, Spring XML or Java) applications to the Red Hat Build of Camel, targeting either Springoot 3, Quarkus or the Camel K Serverless runtime.
-- Migrate Fuse 7 (Karaf or Spring Boot) applications to the Red Hat Build of Camel, targeting either Spring Boot 3, Quarkus or the Camel K Serverless runtime.
-- Start writing Camel 3.x or 4.x applications right away with no effort
+- Migrate Fuse 6.x (Blueprint XML, Spring XML or Java) applications to the Red Hat build of Apache Camel, targeting either Sprin Boot 3, Quarkus or Camel K.
+- Migrate Fuse 7 (Karaf or Spring Boot) applications to the Red Hat build of Apache Camel, targeting either Spring Boot 3, Quarkus or Camel K.
+- Start writing Camel 4.x applications right away with no effort
 
 
 == The Solution
 
-This solution aims to provided an accelerated path to migrating applications from Camel 2 to Camel 3 or Camel 4. More concretely, the material should help people migrating any kind of Fuse 6 or Fuse 7 applications to the latest Red Hat Build of Apache Camel.
+This solution aims to provide an accelerated path to migrating applications from Camel 2 to Camel 3 and Camel 4. More concretely, the material should help people migrating any kind of Fuse 6 or Fuse 7 applications to the latest Red Hat build of Apache Camel.
 
 The Solution Pattern offers a number of *Camel migration templates* which can be leveraged to reduce the migration effort to its bare minimum. 
 
 The demos however focuses on migrating a Fuse 6 application, and more concretely a Camel v2.17 one, in Blueprint XML format, running on Karaf 2. The XML format will be converted to the optimized IO XML one.
 
-This particular usecase has been chosen for the demonstration because it can be considered as potentially the hardest one. Applications running on Fuse 7, no matter which distribution, could use the same approach and will bnefit from a shortest migration effort.
+This particular usecase has been chosen for the demonstration because it can be considered as potentially the hardest one. Applications running on Fuse 7, no matter which distribution, could use the same approach and will benefit from a shortest migration effort.
 
 


### PR DESCRIPTION
I made slight changes in product naming and repositioned Camel K which is not meant as an alternative anymore in v2. In the future there's a potential to extend this solution pattern with the migration path continuing from Quarkus/SB project to directly deploy/manage them with Camel K v2 operator, ...